### PR TITLE
Fix typo in deployment instructions

### DIFF
--- a/ServicesPlus/BeforeDeploy.txt
+++ b/ServicesPlus/BeforeDeploy.txt
@@ -6,5 +6,5 @@
 4- Make sure the "Release" build is selected
 5- Make 3 copies: .exe, .zip and .7z
 6- Update the download page on codeplex and home page.
-7- Responde to discussions and issues pages if any issue were fixed or introduced with the new release
+7- Respond to discussions and issues pages if any issue were fixed or introduced with the new release
 8- Check in the code


### PR DESCRIPTION
## Summary
- correct `Responde` to `Respond` in deployment checklist

## Testing
- `dotnet build ServicesPlus.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a636c18048321ae5b0d341865020c